### PR TITLE
create upsert verification endpoint and server func

### DIFF
--- a/src/app/api/volunteers/[volunteerId]/verifications/route.ts
+++ b/src/app/api/volunteers/[volunteerId]/verifications/route.ts
@@ -1,6 +1,6 @@
 import { upsertVolunteerRoleVerification } from '@/server/actions/Volunteer';
 import { zObjectId } from '@/types/dataModel/base';
-import { zRoleVerificationRequest } from '@/types/dataModel/roleVerifications';
+import { zRoleVerificationRequest } from '@/types/dataModel/roles';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function PATCH(

--- a/src/app/api/volunteers/[volunteerId]/verifications/route.ts
+++ b/src/app/api/volunteers/[volunteerId]/verifications/route.ts
@@ -1,0 +1,41 @@
+import { upsertVolunteerRoleVerification } from '@/server/actions/Volunteer';
+import { zObjectId } from '@/types/dataModel/base';
+import { zRoleVerificationRequest } from '@/types/dataModel/roleVerifications';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { volunteerId: string } }
+) {
+  const objectIdValidationResult = zObjectId.safeParse(params.volunteerId);
+  if (!objectIdValidationResult.success) {
+    return NextResponse.json(
+      { message: 'Invalid Volunteer Id' },
+      { status: 400 }
+    );
+  }
+
+  const body = await request.json();
+  const roleVerificationRequestValidationResult =
+    zRoleVerificationRequest.safeParse(body);
+  if (!roleVerificationRequestValidationResult.success) {
+    return NextResponse.json(
+      { message: 'Invalid Role Verification Request' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await upsertVolunteerRoleVerification(
+      params.volunteerId,
+      roleVerificationRequestValidationResult.data
+    );
+
+    return new NextResponse(undefined, { status: 204 });
+  } catch (err) {
+    return NextResponse.json(
+      { message: 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/server/actions/Volunteer.ts
+++ b/src/server/actions/Volunteer.ts
@@ -9,7 +9,7 @@ import dbConnect from '@/utils/db-connect';
 
 // Temporary code to load org schema until we are using it elsewhere
 import OrganizationSchema from '@/server/models/Organization';
-import { RoleVerificationRequest } from '@/types/dataModel/roleVerifications';
+import { RoleVerificationRequest } from '@/types/dataModel/roles';
 OrganizationSchema;
 
 /**

--- a/src/server/actions/Volunteer.ts
+++ b/src/server/actions/Volunteer.ts
@@ -9,6 +9,7 @@ import dbConnect from '@/utils/db-connect';
 
 // Temporary code to load org schema until we are using it elsewhere
 import OrganizationSchema from '@/server/models/Organization';
+import { RoleVerificationRequest } from '@/types/dataModel/roleVerifications';
 OrganizationSchema;
 
 /**
@@ -61,6 +62,57 @@ export async function deleteEventVolunteer(
         event: eventId,
       });
     return res;
+  } catch (error) {
+    throw error;
+  }
+}
+
+/**
+ * Create or update a volunteer's role verification for a specific role
+ * @param volunteerId The ID of the volunteer to verify
+ * @param roleVerificationRequest The role verification request
+ * @returns The updated volunteer
+ */
+export async function upsertVolunteerRoleVerification(
+  volunteerId: string,
+  roleVerificationRequest: RoleVerificationRequest
+) {
+  try {
+    // TODO: we could save a database call by structuring role verifications like
+    // { 'Medical': { verifier: '...', lastUpdated: '...' }, 'Dental': { verifier: '...', lastUpdated: '...' } }
+    await dbConnect();
+
+    const currentVerifications = await VolunteerSchema.findById(volunteerId)
+      .select('roleVerifications')
+      .exec();
+
+    // update the role verification if it exists
+    let roleVerificationExists = false;
+    currentVerifications?.roleVerifications?.forEach((roleVerification) => {
+      if (roleVerification.role === roleVerificationRequest.role) {
+        roleVerification.verifier = roleVerificationRequest.verifier;
+        roleVerification.lastUpdated = new Date();
+        roleVerificationExists = true;
+      }
+    });
+
+    // add the role verification if it doesn't exist
+    if (!roleVerificationExists) {
+      currentVerifications?.roleVerifications?.push({
+        verifier: roleVerificationRequest.verifier,
+        lastUpdated: new Date(),
+        role: roleVerificationRequest.role,
+      });
+    }
+
+    // update the volunteer with the new role verifications
+    const res = await VolunteerSchema.findByIdAndUpdate(volunteerId, {
+      roleVerifications: currentVerifications?.roleVerifications,
+    });
+
+    if (!res) {
+      throw new Error('Volunteer not found');
+    }
   } catch (error) {
     throw error;
   }

--- a/src/server/models/EventVolunteer.ts
+++ b/src/server/models/EventVolunteer.ts
@@ -1,5 +1,5 @@
 import { EventVolunteerEntity } from '@/types/dataModel/eventVolunteer';
-import { roles } from '@/types/dataModel/volunteer';
+import { roles } from '@/types/dataModel/roleVerifications';
 import { Model, Schema, model, models } from 'mongoose';
 
 const EventVolunteerSchema = new Schema(

--- a/src/server/models/EventVolunteer.ts
+++ b/src/server/models/EventVolunteer.ts
@@ -1,5 +1,5 @@
 import { EventVolunteerEntity } from '@/types/dataModel/eventVolunteer';
-import { roles } from '@/types/dataModel/roleVerifications';
+import { roles } from '@/types/dataModel/roles';
 import { Model, Schema, model, models } from 'mongoose';
 
 const EventVolunteerSchema = new Schema(

--- a/src/server/models/Volunteer.ts
+++ b/src/server/models/Volunteer.ts
@@ -1,7 +1,7 @@
+import { roles } from '@/types/dataModel/roleVerifications';
 import {
   VolunteerEntity,
   backgroundCheckStatuses,
-  roles,
 } from '@/types/dataModel/volunteer';
 import { Model, Schema, model, models } from 'mongoose';
 

--- a/src/server/models/Volunteer.ts
+++ b/src/server/models/Volunteer.ts
@@ -1,4 +1,4 @@
-import { roles } from '@/types/dataModel/roleVerifications';
+import { roles } from '@/types/dataModel/roles';
 import {
   VolunteerEntity,
   backgroundCheckStatuses,

--- a/src/types/dataModel/eventVolunteer.ts
+++ b/src/types/dataModel/eventVolunteer.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import zVolunteer, { zVolunteerResponse } from './volunteer';
 import zOrganization from './organization';
 import zBase, { zObjectId } from './base';
-import { zRole } from './roleVerifications';
+import { zRole } from './roles';
 
 const zEventVolunteer = z.object({
   role: zRole,

--- a/src/types/dataModel/eventVolunteer.ts
+++ b/src/types/dataModel/eventVolunteer.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
-import zVolunteer, { zRole, zVolunteerResponse } from './volunteer';
+import zVolunteer, { zVolunteerResponse } from './volunteer';
 import zOrganization from './organization';
 import zBase, { zObjectId } from './base';
+import { zRole } from './roleVerifications';
 
 const zEventVolunteer = z.object({
   role: zRole,

--- a/src/types/dataModel/roleVerifications.ts
+++ b/src/types/dataModel/roleVerifications.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+// This is a list of roles that need verification to be assigned to a volunteer
+const verifiedRoles = ['Medical', 'Dental', 'Save the Babies'] as const;
+const zVerifiedRole = z.enum(verifiedRoles);
+export type VerifiedRole = z.infer<typeof zVerifiedRole>;
+
+// This is a list of all roles that a volunteer can have
+export const roles = [...verifiedRoles, 'Food'] as const;
+export const zRole = z.enum(roles);
+export type Role = z.infer<typeof zRole>;
+
+export const zRoleVerification = z.object({
+  verifier: z.string(), // TODO: after discussing with bill determine if this should actually be a user
+  lastUpdated: z.date(),
+  role: zVerifiedRole,
+});
+
+export const zRoleVerificationRequest = zRoleVerification.omit({
+  lastUpdated: true,
+});
+
+export interface RoleVerification extends z.infer<typeof zRoleVerification> {}
+export interface RoleVerificationRequest
+  extends z.infer<typeof zRoleVerificationRequest> {}

--- a/src/types/dataModel/roles.ts
+++ b/src/types/dataModel/roles.ts
@@ -11,7 +11,7 @@ export const zRole = z.enum(roles);
 export type Role = z.infer<typeof zRole>;
 
 export const zRoleVerification = z.object({
-  verifier: z.string(), // TODO: after discussing with bill determine if this should actually be a user
+  verifier: z.string(),
   lastUpdated: z.date(),
   role: zVerifiedRole,
 });

--- a/src/types/dataModel/volunteer.ts
+++ b/src/types/dataModel/volunteer.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import zOrganization, { zOrganizationResponse } from './organization';
 import zBase, { zObjectId } from './base';
-import { zRole, zRoleVerification } from './roleVerifications';
+import { zRole, zRoleVerification } from './roles';
 
 export const backgroundCheckStatuses = [
   'Passed',

--- a/src/types/dataModel/volunteer.ts
+++ b/src/types/dataModel/volunteer.ts
@@ -1,10 +1,7 @@
 import { z } from 'zod';
 import zOrganization, { zOrganizationResponse } from './organization';
 import zBase, { zObjectId } from './base';
-
-export const roles = ['Medical', 'Dental', 'Food', 'Save the Babies'] as const;
-export const zRole = z.enum(roles);
-export type Role = z.infer<typeof zRole>;
+import { zRole, zRoleVerification } from './roleVerifications';
 
 export const backgroundCheckStatuses = [
   'Passed',
@@ -26,15 +23,7 @@ const zVolunteer = z.object({
       lastUpdated: z.date(),
     })
     .optional(),
-  roleVerifications: z
-    .array(
-      z.object({
-        verifier: z.string(), // TODO: after discussing with bill determine if this should actually be a user
-        lastUpdated: z.date(),
-        role: zRole,
-      })
-    )
-    .optional(),
+  roleVerifications: z.array(zRoleVerification).optional(),
   softDelete: z.boolean(),
 });
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes. Please also include relevant motivation and context. -->
This PR creates the server function and API endpoint for upserting role verifications on a volunteer. During this process, I pulled out the zod role verification stuff into its own file to prevent the `volunteers.ts` file from getting too cluttered. This meant I had to change some other files to fix imports.

I have a note in a comment somewhere, but I think we should reconsider how we structure role verifications. Currently, they are stored as an array of verifications. To update or insert a role verification, we first need to get the current ones from the database, search the array, and update or insert an element. If we modified this to make role verifications an object keyed on the type of verification, all of this processing goes away and we save on a DB call. 

### Testing
To test this PR, I created role verifications on a volunteer and noted behavior when trying to:
- Create a new valid verification
- Update an existing verification
- Create a verification for an invalid role

## Relevant issue(s)

<!-- List the issues related to this PR here in the format "#[ISSUE NUMBER]". Ideally, there should only be one issue per PR. -->
<!-- For example:
- #1
- #2
- #27 
 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
