### PR TITLE
77 create event api and server function

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,37 @@
+import { createEvent } from '@/server/actions/Event';
+import { zCreateEventRequest } from '@/types/dataModel/event';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+
+  // validate the request body
+  const validationResult = zCreateEventRequest.safeParse(body);
+  if (!validationResult.success) {
+    return NextResponse.json(
+      {
+        message: 'Invalid request body',
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // create the event
+    const eventId = await createEvent(validationResult.data);
+
+    return NextResponse.json(
+      {
+        eventId,
+      },
+      { status: 200 }
+    );
+  } catch (e) {
+    return NextResponse.json(
+      {
+        message: 'Internal Server Error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -22,9 +22,9 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(
       {
-        eventId,
+        _id: eventId,
       },
-      { status: 200 }
+      { status: 201 }
     );
   } catch (e) {
     return NextResponse.json(

--- a/src/server/actions/Event.ts
+++ b/src/server/actions/Event.ts
@@ -1,0 +1,27 @@
+import { CreateEventRequest } from '@/types/dataModel/event';
+import Event from '../models/Event';
+import { createRecurringEvent } from './RecurringEvent';
+
+export async function createEvent(
+  createEventReq: CreateEventRequest
+): Promise<string> {
+  try {
+    // first create the event
+    const res = await Event.create(createEventReq);
+    if (!res) {
+      throw new Error('Event not created');
+    }
+
+    // create recurring event if it is a recurring event
+    if (createEventReq.isRecurring) {
+      await createRecurringEvent({
+        event: res._id.toString(),
+        recurrence: createEventReq.recurrence,
+      });
+    }
+
+    return res._id.toString();
+  } catch (e) {
+    throw e;
+  }
+}

--- a/src/server/actions/Event.ts
+++ b/src/server/actions/Event.ts
@@ -1,11 +1,13 @@
 import { CreateEventRequest } from '@/types/dataModel/event';
 import Event from '../models/Event';
 import { createRecurringEvent } from './RecurringEvent';
+import dbConnect from '@/utils/db-connect';
 
 export async function createEvent(
   createEventReq: CreateEventRequest
 ): Promise<string> {
   try {
+    await dbConnect();
     // first create the event
     const res = await Event.create(createEventReq);
     if (!res) {

--- a/src/server/actions/RecurringEvent.ts
+++ b/src/server/actions/RecurringEvent.ts
@@ -1,0 +1,16 @@
+import { CreateRecurringEventRequest } from '@/types/dataModel/recurringEvent';
+import RecurringEvent from '../models/RecurringEvent';
+
+export async function createRecurringEvent(
+  createRecurringEventReq: CreateRecurringEventRequest
+): Promise<string> {
+  try {
+    const res = await RecurringEvent.create(createRecurringEventReq);
+    if (!res) {
+      throw new Error('Recurring Event not created');
+    }
+    return res._id.toString();
+  } catch (e) {
+    throw e;
+  }
+}

--- a/src/server/actions/RecurringEvent.ts
+++ b/src/server/actions/RecurringEvent.ts
@@ -1,10 +1,12 @@
 import { CreateRecurringEventRequest } from '@/types/dataModel/recurringEvent';
 import RecurringEvent from '../models/RecurringEvent';
+import dbConnect from '@/utils/db-connect';
 
 export async function createRecurringEvent(
   createRecurringEventReq: CreateRecurringEventRequest
 ): Promise<string> {
   try {
+    await dbConnect();
     const res = await RecurringEvent.create(createRecurringEventReq);
     if (!res) {
       throw new Error('Recurring Event not created');

--- a/src/types/dataModel/event.ts
+++ b/src/types/dataModel/event.ts
@@ -6,9 +6,9 @@ const zEvent = z.object({
   name: z.string(),
   description: z.string().optional(),
   eventLocation: z.string().optional(),
-  startAt: z.date(),
-  endAt: z.date(),
-  date: z.date(),
+  startAt: z.coerce.date(),
+  endAt: z.coerce.date(),
+  date: z.coerce.date().optional(),
   eventRoles: z.array(zRole),
   emailBodies: z.array(z.string()),
   isRecurring: z.boolean(),
@@ -21,8 +21,16 @@ export const zEventEntity = zEvent.extend({
 
 export const zEventResponse = zEventEntity;
 
+export const zCreateEventRequest = z.discriminatedUnion('isRecurring', [
+  zEvent
+    .omit({ parentEvent: true })
+    .extend({ isRecurring: z.literal(true), recurrence: z.string() }),
+  zEvent.omit({ parentEvent: true }).extend({ isRecurring: z.literal(false) }),
+]);
+
 export interface Event extends z.infer<typeof zEvent> {}
 export interface EventEntity extends z.infer<typeof zEventEntity> {}
 export interface EventResponse extends z.infer<typeof zEventResponse> {}
+export type CreateEventRequest = z.infer<typeof zCreateEventRequest>; // needs to be a type to support discriminated union
 
 export default zEvent;

--- a/src/types/dataModel/event.ts
+++ b/src/types/dataModel/event.ts
@@ -25,7 +25,9 @@ export const zCreateEventRequest = z.discriminatedUnion('isRecurring', [
   zEvent
     .omit({ parentEvent: true })
     .extend({ isRecurring: z.literal(true), recurrence: z.string() }),
-  zEvent.omit({ parentEvent: true }).extend({ isRecurring: z.literal(false) }),
+  zEvent
+    .omit({ parentEvent: true, date: true })
+    .extend({ isRecurring: z.literal(false) }),
 ]);
 
 export interface Event extends z.infer<typeof zEvent> {}

--- a/src/types/dataModel/event.ts
+++ b/src/types/dataModel/event.ts
@@ -21,13 +21,15 @@ export const zEventEntity = zEvent.extend({
 
 export const zEventResponse = zEventEntity;
 
+/* This is a union between two types.
+ * If the event is a recurring event, it will not have a date property, but it will have a recurrence property
+ * If the event is not a recurring event, it will have a date property, but will not have a recurrence property
+ */
 export const zCreateEventRequest = z.discriminatedUnion('isRecurring', [
   zEvent
-    .omit({ parentEvent: true })
-    .extend({ isRecurring: z.literal(true), recurrence: z.string() }),
-  zEvent
     .omit({ parentEvent: true, date: true })
-    .extend({ isRecurring: z.literal(false) }),
+    .extend({ isRecurring: z.literal(true), recurrence: z.string() }),
+  zEvent.omit({ parentEvent: true }).extend({ isRecurring: z.literal(false) }),
 ]);
 
 export interface Event extends z.infer<typeof zEvent> {}

--- a/src/types/dataModel/recurringEvent.ts
+++ b/src/types/dataModel/recurringEvent.ts
@@ -16,8 +16,15 @@ export const zRecurringEventResponse = zRecurringEventEntity.extend({
   event: zEventResponse,
 });
 
+export const zCreateRecurringEventRequest = zRecurringEvent.extend({
+  event: zObjectId,
+});
+
 export type RecurringEvent = z.infer<typeof zRecurringEvent>;
 export type RecurringEventEntity = z.infer<typeof zRecurringEventEntity>;
 export type RecurringEventResponse = z.infer<typeof zRecurringEventResponse>;
+export type CreateRecurringEventRequest = z.infer<
+  typeof zCreateRecurringEventRequest
+>;
 
 export default zRecurringEvent;


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes. Please also include relevant motivation and context. -->
This PR creates a server function and corresponding endpoint for creating events. As a part of this, I've created a server function for creating events, and one for creating recurring events. Creating a recurring event uses the same endpoint, but sets the `isRecurring` field to true and passes in a string called `recurrence`.

I updated the data model to include these requests.

I am also making an assumption here. I am thinking the RRULE string should be generated on the frontend. this reduces complexity in the server function at the cost of adding it to the frontend. i am open to changing this, but this was the easiest path forward for now.

To test this PR I:
- Created an event that doesn't recur and verified it must have the `date` field set
- Create a recurring event and verified it needs the `recurrence` field set
- Hit the endpoint with a bad body.

## Relevant issue(s)

<!-- List the issues related to this PR here in the format "#[ISSUE NUMBER]". Ideally, there should only be one issue per PR. -->
<!-- For example:
- #1
- #2
 -->
- #77 

## Questions
<!-- Please note any questions or concerns about this PR here, or specific areas you would like reviewers to pay special attention to -->

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
