### PR TITLE
simplify cmerror construction

### DIFF
--- a/src/utils/cmerror.ts
+++ b/src/utils/cmerror.ts
@@ -68,9 +68,14 @@ export default class CMError extends Error {
   readonly type: CMErrorType;
 
   // Constructs a CMError based on a CMErrorType value
-  // If message is not defined, uses a default message for the CMErrorType
-  constructor(errorType: CMErrorType, message?: string) {
-    super(message ?? getCMErrorTypeMsg(errorType));
+  // Generates CMError.message from source and the message template for the given errorType
+  // If overrideErrMsg = true, the template is ignored source is copied directly to CMError.message
+  constructor(
+    errorType: CMErrorType,
+    source?: string,
+    overrideErrMsg: boolean = false
+  ) {
+    super(overrideErrMsg ? source : getCMErrorTypeMsg(errorType, source));
     this.type = errorType;
   }
 

--- a/src/utils/cmerror.ts
+++ b/src/utils/cmerror.ts
@@ -69,7 +69,7 @@ export default class CMError extends Error {
 
   // Constructs a CMError based on a CMErrorType value
   // Generates CMError.message from source and the message template for the given errorType
-  // If overrideErrMsg = true, the template is ignored source is copied directly to CMError.message
+  // If overrideErrMsg = true, the template is ignored and source is copied directly to CMError.message
   constructor(
     errorType: CMErrorType,
     source?: string,


### PR DESCRIPTION
# Description
Changes CMError constructor to use the error message templates by default, with an optional parameter to disable this behavior. This reduces redundancy in most use cases.

- Old Call Signature: `CMError(CMErrorType, string?)`
- New Call Signature: `CMError(CMErrorType, string?, boolean?)`

Usually, you want to use the error message templates. To do this currently requires calling `getCMErrorTypeMsg()` with the same error type that you passed into the constructor to get the error message string, which is a bit redundant and messy. With this change, the constructor will do this by default. To ignore the predefined templates and instead use a raw string as before, set `overrideErrMsg` to true.

| Before | After |
| ------------- | ------------- |
| `new CMError(CMErrorType.foo, getCMErrorTypeMsg(CMErrorType.foo, "bar"))` | `new CMError(CMErrorType.foo, "bar"))` |
| `new CMError(CMErrorType.foo, "bar")`  | `new CMErrorType(CMErrorType.foo, "bar", true)` |

## Relevant issue(s)

None, standalone request from Andy ❤️

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
