### PR TITLE
51 add  id false to any child objects in mongoose schemas

### DIFF
--- a/src/server/models/Volunteer.ts
+++ b/src/server/models/Volunteer.ts
@@ -66,12 +66,10 @@ const VolunteerSchema = new Schema(
             required: true,
             enum: roles,
           },
-          //_id: false,
+          _id: false,
         },
-        //{ _id: false },
       ],
       required: false,
-      //_id: false
     },
     softDelete: {
       type: Boolean,

--- a/src/server/models/Volunteer.ts
+++ b/src/server/models/Volunteer.ts
@@ -48,6 +48,7 @@ const VolunteerSchema = new Schema(
         },
       },
       required: false,
+      _id: false,
     },
     roleVerifications: {
       type: [
@@ -65,9 +66,12 @@ const VolunteerSchema = new Schema(
             required: true,
             enum: roles,
           },
+          //_id: false,
         },
+        //{ _id: false },
       ],
       required: false,
+      //_id: false
     },
     softDelete: {
       type: Boolean,


### PR DESCRIPTION
# Description
Fixed erroneously auto-generating IDs for child objects in Volunteer (backgroundCheck, entries in roleVerifications list).

## Relevant issue(s)

#51

## Questions
AFAIK no other database entries have this issue rn. Just make sure that ppl do this for any new document definitions going forward.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
