### PR TITLE
97 hook up checkinview to backend

### DIFF
--- a/src/components/CheckInForm/index.tsx
+++ b/src/components/CheckInForm/index.tsx
@@ -1,5 +1,8 @@
 import { EventResponse } from '@/types/dataModel/event';
-import { OrganizationResponse } from '@/types/dataModel/organization';
+import {
+  CreateOrganizationRequest,
+  OrganizationResponse,
+} from '@/types/dataModel/organization';
 import { Role } from '@/types/dataModel/roles';
 import { VolunteerResponse } from '@/types/dataModel/volunteer';
 import { CheckInFormData } from '@/types/forms/checkIn';
@@ -11,6 +14,7 @@ import {
   RadioGroup,
   TextField,
   Typography,
+  createFilterOptions,
 } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 
@@ -20,6 +24,36 @@ interface Props {
   organizations: OrganizationResponse[];
   checkInData: CheckInFormData;
   onChange: (checkInData: CheckInFormData) => void;
+}
+
+type OrganizationOption = OrganizationResponse & { display?: string };
+
+const filter = createFilterOptions<OrganizationOption>();
+
+async function createNewOrganization(name: string) {
+  const orgReq: CreateOrganizationRequest = {
+    name,
+  };
+
+  // make post req
+  try {
+    const res = await fetch('/api/organizations', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(orgReq),
+    });
+
+    if (res.status === 201) {
+      const data = await res.json();
+
+      // validate response
+      return data.id;
+    }
+  } catch (e) {
+    console.error('failed to create new organization', e);
+  }
 }
 
 // TODO prevent input of role that the volunteer is not verified for
@@ -79,6 +113,7 @@ export default function CheckInForm(props: Props) {
         <Autocomplete
           sx={{ mt: 2 }}
           freeSolo
+          value={props.checkInData.firstName || ''}
           options={volunteerOptions}
           isOptionEqualToValue={(option, value) => option._id === value._id}
           getOptionLabel={(vol) =>
@@ -115,6 +150,7 @@ export default function CheckInForm(props: Props) {
           sx={{ mt: 2 }}
           freeSolo
           autoComplete
+          value={props.checkInData.lastName || ''}
           options={volunteerOptions}
           isOptionEqualToValue={(option, value) => option._id === value._id}
           getOptionLabel={(vol) =>
@@ -151,6 +187,7 @@ export default function CheckInForm(props: Props) {
           sx={{ mt: 2 }}
           freeSolo
           autoComplete
+          value={props.checkInData.email || ''}
           options={volunteerOptions}
           isOptionEqualToValue={(option, value) => option._id === value._id}
           getOptionLabel={(vol) => (typeof vol === 'string' ? vol : vol.email)}
@@ -182,6 +219,7 @@ export default function CheckInForm(props: Props) {
         <TextField
           sx={{ mt: 2 }}
           label="Phone Number"
+          value={props.checkInData.phoneNumber || ''}
           onChange={(e) => {
             props.onChange({
               ...props.checkInData,
@@ -194,6 +232,7 @@ export default function CheckInForm(props: Props) {
         <TextField
           sx={{ mt: 2 }}
           label="Address"
+          value={props.checkInData.address || ''}
           onChange={(e) => {
             props.onChange({ ...props.checkInData, address: e.target.value });
           }}
@@ -206,6 +245,7 @@ export default function CheckInForm(props: Props) {
       </Typography>
       <RadioGroup
         sx={{ pb: 2 }}
+        value={props.checkInData.role || null}
         onChange={(e) =>
           props.onChange({ ...props.checkInData, role: e.target.value as Role })
         }
@@ -224,30 +264,57 @@ export default function CheckInForm(props: Props) {
       <Autocomplete
         freeSolo
         autoComplete
-        options={props.organizations}
+        value={(props.checkInData.organization as OrganizationOption) || ''}
+        options={props.organizations as OrganizationOption[]}
         isOptionEqualToValue={(option, value) => option._id === value._id}
         getOptionLabel={(org) => (typeof org === 'string' ? org : org.name)}
         renderOption={(props, option) => {
           return (
             <li {...props} key={option._id}>
-              {option.name}
+              {option.display ?? option.name}
             </li>
           );
         }}
         renderInput={(params) => (
-          <TextField
-            {...params}
-            label="Organization (optional)"
-            onChange={(e) => {
-              props.onChange({
-                ...props.checkInData,
-                organization: e.target.value,
-              });
-            }}
-          />
+          <TextField {...params} label="Organization (optional)" />
         )}
-        onInputChange={(_, value) => {
-          props.onChange({ ...props.checkInData, organization: value });
+        filterOptions={(options, params) => {
+          const filtered = filter(options, params);
+
+          const { inputValue } = params;
+          // Suggest the creation of a new value
+          const isExisting = options.some(
+            (option) => inputValue === option.name
+          );
+          if (inputValue !== '' && !isExisting) {
+            filtered.push({
+              name: inputValue,
+              display: `Add "${inputValue}"`,
+              softDelete: false,
+              _id: '-1',
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            });
+          }
+
+          return filtered;
+        }}
+        clearOnBlur
+        onChange={(_, value) => {
+          if (typeof value === 'string') {
+            // todo: set error state (idk how this would happen)
+            console.error('string value in organization autocomplete');
+          } else if (value?.display) {
+            // create new organization
+            createNewOrganization(value.name).then((id) => {
+              if (id) {
+                const newOrg = { ...value, _id: id };
+                props.onChange({ ...props.checkInData, organization: newOrg });
+              }
+            });
+          } else if (value) {
+            props.onChange({ ...props.checkInData, organization: value });
+          }
         }}
       />
     </>

--- a/src/components/CheckInForm/index.tsx
+++ b/src/components/CheckInForm/index.tsx
@@ -282,10 +282,13 @@ export default function CheckInForm(props: Props) {
           const filtered = filter(options, params);
 
           const { inputValue } = params;
+
           // Suggest the creation of a new value
           const isExisting = options.some(
             (option) => inputValue === option.name
           );
+
+          // If the new value is not already an option, display it with "Add" text
           if (inputValue !== '' && !isExisting) {
             filtered.push({
               name: inputValue,

--- a/src/components/CheckInForm/index.tsx
+++ b/src/components/CheckInForm/index.tsx
@@ -48,11 +48,11 @@ async function createNewOrganization(name: string) {
     if (res.status === 201) {
       const data = await res.json();
 
-      // validate response
+      // TODO validate response
       return data.id;
     }
   } catch (e) {
-    console.error('failed to create new organization', e);
+    console.error('failed to create new organization: ', e);
   }
 }
 
@@ -281,14 +281,15 @@ export default function CheckInForm(props: Props) {
         filterOptions={(options, params) => {
           const filtered = filter(options, params);
 
+          // what is typed in the field
           const { inputValue } = params;
 
-          // Suggest the creation of a new value
+          // Checks if the inputValue match an existing organization
           const isExisting = options.some(
             (option) => inputValue === option.name
           );
 
-          // If the new value is not already an option, display it with "Add" text
+          // If the inputValue does not match an existing organization, display it as `Add "[inputValue]"`
           if (inputValue !== '' && !isExisting) {
             filtered.push({
               name: inputValue,
@@ -305,16 +306,21 @@ export default function CheckInForm(props: Props) {
         clearOnBlur
         onChange={(_, value) => {
           if (typeof value === 'string') {
-            // todo: set error state (idk how this would happen)
-            console.error('string value in organization autocomplete');
+            // TODO: set error state (unknown how this would happen)
+            console.error(
+              'String value in organization autocomplete. Should only be objects'
+            );
+            // if the user has input a custom value
           } else if (value?.display) {
             // create new organization
             createNewOrganization(value.name).then((id) => {
+              // updates the currently selected organization in state
               if (id) {
                 const newOrg = { ...value, _id: id };
                 props.onChange({ ...props.checkInData, organization: newOrg });
               }
             });
+            // if the user selected an existing organization, update it in state
           } else if (value) {
             props.onChange({ ...props.checkInData, organization: value });
           }

--- a/src/components/CheckInForm/index.tsx
+++ b/src/components/CheckInForm/index.tsx
@@ -304,6 +304,7 @@ export default function CheckInForm(props: Props) {
           return filtered;
         }}
         clearOnBlur
+        autoHighlight
         onChange={(_, value) => {
           if (typeof value === 'string') {
             // TODO: set error state (unknown how this would happen)
@@ -323,6 +324,11 @@ export default function CheckInForm(props: Props) {
             // if the user selected an existing organization, update it in state
           } else if (value) {
             props.onChange({ ...props.checkInData, organization: value });
+          } else {
+            props.onChange({
+              ...props.checkInData,
+              organization: undefined,
+            });
           }
         }}
       />

--- a/src/types/forms/checkIn.ts
+++ b/src/types/forms/checkIn.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { zRole } from '../dataModel/roles';
+import { zOrganizationResponse } from '../dataModel/organization';
 
 const zCheckInFormData = z.object({
   firstName: z.string(),
@@ -8,7 +9,7 @@ const zCheckInFormData = z.object({
   phoneNumber: z.string(),
   address: z.string(),
   role: zRole,
-  organization: z.string().optional(),
+  organization: zOrganizationResponse.optional(),
 });
 
 export interface CheckInFormData extends z.infer<typeof zCheckInFormData> {}

--- a/src/utils/transformers/check-in.ts
+++ b/src/utils/transformers/check-in.ts
@@ -9,7 +9,7 @@ export function transformCheckInFormDataToCreateEventVolunteerRequest(
   event: EventResponse
 ): CreateEventVolunteerRequest {
   return {
-    volunteer: volunteer?._id,
+    volunteer: volunteer._id,
     event: event._id,
     role: formData.role,
     organization: formData.organization?._id,

--- a/src/utils/transformers/check-in.ts
+++ b/src/utils/transformers/check-in.ts
@@ -1,0 +1,17 @@
+import { EventResponse } from '@/types/dataModel/event';
+import { CreateEventVolunteerRequest } from '@/types/dataModel/eventVolunteer';
+import { VolunteerResponse } from '@/types/dataModel/volunteer';
+import { CheckInFormData } from '@/types/forms/checkIn';
+
+export function transformCheckInFormDataToCreateEventVolunteerRequest(
+  formData: CheckInFormData,
+  volunteer: VolunteerResponse,
+  event: EventResponse
+): CreateEventVolunteerRequest {
+  return {
+    volunteer: volunteer?._id,
+    event: event._id,
+    role: formData.role,
+    organization: formData.organization?._id,
+  };
+}

--- a/src/views/CheckInView/index.tsx
+++ b/src/views/CheckInView/index.tsx
@@ -5,6 +5,7 @@ import type { EventResponse } from '@/types/dataModel/event';
 import type { OrganizationResponse } from '@/types/dataModel/organization';
 import type { VolunteerResponse } from '@/types/dataModel/volunteer';
 import { CheckInFormData } from '@/types/forms/checkIn';
+import { transformCheckInFormDataToCreateEventVolunteerRequest } from '@/utils/transformers/check-in';
 import { Button, Typography } from '@mui/material';
 import Grid2 from '@mui/material/Unstable_Grid2/Grid2';
 import { useState } from 'react';
@@ -20,8 +21,47 @@ export default function CheckInView(props: CheckInViewProps) {
     {} as CheckInFormData
   );
 
-  const onCheckIn = () => {
-    console.log(formData);
+  const onCheckIn = async () => {
+    // find volunteer by email
+    const volunteer = props.volunteers.find((v) => v.email === formData.email);
+
+    // todo: better error handling
+    if (!volunteer) {
+      console.error('volunteer not found');
+      return;
+    }
+
+    const eventVolReq = transformCheckInFormDataToCreateEventVolunteerRequest(
+      formData,
+      volunteer,
+      props.event
+    );
+
+    // make post req
+    try {
+      const res = await fetch(
+        `/api/events/${props.event._id}/volunteers/${volunteer?._id}/check-in`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(eventVolReq),
+        }
+      );
+
+      if (res.status === 201) {
+        // validate response and show success message
+
+        // reset form
+        setFormData({} as CheckInFormData);
+      } else {
+        const data = await res.json();
+        console.error('failed to check in', data);
+      }
+    } catch (e) {
+      console.error('failed to check in', e);
+    }
   };
 
   return (

--- a/src/views/CheckInView/index.tsx
+++ b/src/views/CheckInView/index.tsx
@@ -25,9 +25,9 @@ export default function CheckInView(props: CheckInViewProps) {
     // find volunteer by email
     const volunteer = props.volunteers.find((v) => v.email === formData.email);
 
-    // todo: better error handling
+    // TODO: better error handling
     if (!volunteer) {
-      console.error('volunteer not found');
+      console.error(`volunteer with email ${formData.email} not found`);
       return;
     }
 
@@ -40,7 +40,7 @@ export default function CheckInView(props: CheckInViewProps) {
     // make post req
     try {
       const res = await fetch(
-        `/api/events/${props.event._id}/volunteers/${volunteer?._id}/check-in`,
+        `/api/events/${props.event._id}/volunteers/${volunteer._id}/check-in`,
         {
           method: 'POST',
           headers: {
@@ -51,7 +51,7 @@ export default function CheckInView(props: CheckInViewProps) {
       );
 
       if (res.status === 201) {
-        // validate response and show success message
+        // TODO: validate response and show success message
 
         // reset form
         setFormData({} as CheckInFormData);


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes. Please also include relevant motivation and context. -->
This PR makes the check in page and form actually work! When this is merged, users will be able to check volunteers into events.

This is a bit of a beast. I had to do a couple things that I'll list here:
- I had to update the `CheckInForm` to better support the existing backend wrt creating new organizations. Originally, the form just kept track of the org name, now it keeps track of the org object. Since the backend expects an org id, in the case there is a new org we have to first create that in the DB. The select now has an option to "Add 'new org name'" in the case where the org they are trying to volunteer with doesnt exist.
- set value props on fields in the form. This should have been in the story desc for creating the form, my bad. we need to be able to control the form state from the parent so that it can clear the form after checking in. it now does this
- a transformer function to convert `CheckInFormData` to `CreateEventVolunteerRequest`. self explainatory
- make the `checkIn` function actually talk to the backend. this was in the story desc.

## Relevant issue(s)
- #97 
<!-- List the issues related to this PR here in the format "#[ISSUE NUMBER]". Ideally, there should only be one issue per PR. -->
<!-- For example:
- #1
- #2
 -->

## Questions
<!-- Please note any questions or concerns about this PR here, or specific areas you would like reviewers to pay special attention to -->

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
