### PR TITLE
109-create-updated-event-response-type

### DIFF
--- a/src/types/dataModel/event.ts
+++ b/src/types/dataModel/event.ts
@@ -19,7 +19,13 @@ export const zEventEntity = zEvent.extend({
   ...zBase.shape,
 });
 
-export const zEventResponse = zEventEntity;
+/* Same as zEventEntity when isRecurring is false
+ * Adds 'recurrence' and 'recurringEventId' if its true
+ */
+export const zEventResponse = z.discriminatedUnion('isRecurring', [
+  zEventEntity.extend({ recurrence: z.string(), recurringEventId: zObjectId }),
+  zEventEntity.extend({ ...zBase.shape }),
+]);
 
 /* This is a union between two types.
  * If the event is a recurring event, it will not have a date property, but it will have a recurrence property
@@ -34,7 +40,7 @@ export const zCreateEventRequest = z.discriminatedUnion('isRecurring', [
 
 export interface Event extends z.infer<typeof zEvent> {}
 export interface EventEntity extends z.infer<typeof zEventEntity> {}
-export interface EventResponse extends z.infer<typeof zEventResponse> {}
+export type EventResponse = z.infer<typeof zEventResponse>;
 export type CreateEventRequest = z.infer<typeof zCreateEventRequest>; // needs to be a type to support discriminated union
 
 export default zEvent;

--- a/src/types/dataModel/event.ts
+++ b/src/types/dataModel/event.ts
@@ -23,8 +23,13 @@ export const zEventEntity = zEvent.extend({
  * Adds 'recurrence' and 'recurringEventId' if its true
  */
 export const zEventResponse = z.discriminatedUnion('isRecurring', [
-  zEventEntity.extend({ recurrence: z.string(), recurringEventId: zObjectId }),
-  zEventEntity.extend({ ...zBase.shape }),
+  zEventEntity.extend({
+    isRecurring: z.literal(true),
+    recurrence: z.string(),
+    recurringEventId: zObjectId,
+    ...zBase.shape,
+  }),
+  zEventEntity.extend({ isRecurring: z.literal(false), ...zBase.shape }),
 ]);
 
 /* This is a union between two types.


### PR DESCRIPTION
# Description
Changed zEventResponse to a discriminated union. When `isRecurring` is false, the rest is identical. When `isRecurring` is true, two additional fields `recurrence` and `recurringEventId` are present.

## Relevant issue(s)

#109 

## Questions

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature :D

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have assigned reviewers to this PR

# Test Page

```
import { EventResponse } from '@/types/dataModel/event';
import Event from '@/components/Event';

const testER = {
  isRecurring: false,
  name: 'testEvent',
  startAt: new Date(1970, 1, 1),
  endAt: new Date(1970, 1, 2),
  eventRoles: ['Food'],
} as EventResponse;

export default function Home() {
  return <Event event={testER} eventVolunteers={[]} />;
}
```
