### PR TITLE
Filter out soft-deleted documents

### DIFF
--- a/src/components/YearSelector/index.tsx
+++ b/src/components/YearSelector/index.tsx
@@ -1,0 +1,81 @@
+'use client';
+import { ArrowBackIosNew, ArrowForwardIos } from '@mui/icons-material';
+import {
+  IconButton,
+  Button,
+  Typography,
+  Popover,
+  ListItemButton,
+} from '@mui/material';
+import { Dispatch, SetStateAction, useState } from 'react';
+
+interface YearSelectorProps {
+  selectedYear: number;
+  onChange: Dispatch<SetStateAction<number>>;
+}
+
+export default function YearSelector(props: YearSelectorProps) {
+  const MIN_YEAR = 2024;
+  const CURR_YEAR = new Date().getFullYear();
+  const YEAR_OPTIONS: number[] = [];
+
+  // all years from now to 2024 (launch date) in descending order
+  for (let i = CURR_YEAR; i >= MIN_YEAR; i--) {
+    YEAR_OPTIONS.push(i);
+  }
+
+  // what the year dropdown is tied to. Only visible if !== null
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  return (
+    <>
+      <IconButton
+        size="small"
+        disabled={props.selectedYear === MIN_YEAR}
+        onClick={() => props.onChange((currYear) => currYear - 1)}
+      >
+        <ArrowBackIosNew sx={{ width: 15, height: 15 }} />
+      </IconButton>
+      <Button
+        variant="text"
+        size="large"
+        sx={{ width: '5rem', color: 'black' }}
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+      >
+        <Typography variant="h6">{props.selectedYear}</Typography>
+      </Button>
+
+      <Popover
+        open={!!anchorEl}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+      >
+        {YEAR_OPTIONS.map((option) => (
+          <ListItemButton
+            key={option}
+            selected={option === props.selectedYear}
+            autoFocus={option === props.selectedYear}
+            onClick={() => {
+              props.onChange(option);
+              setAnchorEl(null);
+            }}
+          >
+            <Typography sx={{ p: 1 }}>{option}</Typography>
+          </ListItemButton>
+        ))}
+      </Popover>
+
+      <IconButton
+        size="small"
+        disabled={props.selectedYear === CURR_YEAR}
+        onClick={() => props.onChange((currYear) => currYear + 1)}
+      >
+        <ArrowForwardIos sx={{ width: 15, height: 15 }} />
+      </IconButton>
+    </>
+  );
+}

--- a/src/components/YearSelector/index.tsx
+++ b/src/components/YearSelector/index.tsx
@@ -27,6 +27,7 @@ export default function YearSelector() {
     setCurrYear(new Date().getFullYear());
   }, []);
 
+  // whenever the user updates the year, update the search params
   useEffect(() => {
     setSelectedYear(selectedYear);
     const params = new URLSearchParams(searchParams.toString());
@@ -36,12 +37,13 @@ export default function YearSelector() {
     router.push(pathname + '?' + params);
   }, [pathname, router, searchParams, selectedYear]);
 
+  // sets initial year options. Includes all years from 2024 to current year
   const YEAR_OPTIONS = useMemo(() => {
-    const ops: number[] = [];
+    const options: number[] = [];
     for (let i = CURR_YEAR; i >= MIN_YEAR; i--) {
-      ops.push(i);
+      options.push(i);
     }
-    return ops;
+    return options;
   }, [CURR_YEAR]);
 
   return (

--- a/src/components/YearSelector/index.tsx
+++ b/src/components/YearSelector/index.tsx
@@ -8,7 +8,7 @@ import {
   ListItemButton,
 } from '@mui/material';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 const MIN_YEAR = 2024;
 export default function YearSelector() {
@@ -18,24 +18,28 @@ export default function YearSelector() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
-  const [selectedYear, setSelectedYear] = useState<number>(
-    parseInt(searchParams.get('year') || String(new Date().getFullYear()))
+  const selectedYear: number = parseInt(
+    searchParams.get('year') || String(MIN_YEAR)
+  );
+
+  // whenever the user updates the year, update the search params
+  const updateQueryParam = useCallback(
+    (newYear: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('year', newYear.toString());
+
+      params.toString();
+      router.push(pathname + '?' + params);
+    },
+    [pathname, router, searchParams]
   );
 
   // all years from now to 2024 (launch date) in descending order
   useEffect(() => {
-    setCurrYear(new Date().getFullYear());
-  }, []);
-
-  // whenever the user updates the year, update the search params
-  useEffect(() => {
-    setSelectedYear(selectedYear);
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('year', selectedYear.toString());
-
-    params.toString();
-    router.push(pathname + '?' + params);
-  }, [pathname, router, searchParams, selectedYear]);
+    const currYear = new Date().getFullYear();
+    setCurrYear(currYear);
+    updateQueryParam(currYear);
+  }, [updateQueryParam]);
 
   // sets initial year options. Includes all years from 2024 to current year
   const YEAR_OPTIONS = useMemo(() => {
@@ -51,7 +55,7 @@ export default function YearSelector() {
       <IconButton
         size="small"
         disabled={selectedYear <= MIN_YEAR}
-        onClick={() => setSelectedYear((currYear) => currYear - 1)}
+        onClick={() => updateQueryParam(selectedYear - 1)}
       >
         <ArrowBackIosNew sx={{ width: 15, height: 15 }} />
       </IconButton>
@@ -79,7 +83,7 @@ export default function YearSelector() {
             selected={option === selectedYear}
             autoFocus={option === selectedYear}
             onClick={() => {
-              setSelectedYear(option);
+              updateQueryParam(option);
               setAnchorEl(null);
             }}
           >
@@ -91,7 +95,7 @@ export default function YearSelector() {
       <IconButton
         size="small"
         disabled={selectedYear >= CURR_YEAR}
-        onClick={() => setSelectedYear((currYear) => currYear + 1)}
+        onClick={() => updateQueryParam(selectedYear + 1)}
       >
         <ArrowForwardIos sx={{ width: 15, height: 15 }} />
       </IconButton>

--- a/src/components/YearSelector/index.tsx
+++ b/src/components/YearSelector/index.tsx
@@ -7,22 +7,28 @@ import {
   Popover,
   ListItemButton,
 } from '@mui/material';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 
 interface YearSelectorProps {
   selectedYear: number;
   onChange: Dispatch<SetStateAction<number>>;
 }
 
+const MIN_YEAR = 2024;
 export default function YearSelector(props: YearSelectorProps) {
-  const MIN_YEAR = 2024;
-  const CURR_YEAR = new Date().getFullYear();
-  const YEAR_OPTIONS: number[] = [];
-
+  const [CURR_YEAR, setCurrYear] = useState<number>(0);
   // all years from now to 2024 (launch date) in descending order
-  for (let i = CURR_YEAR; i >= MIN_YEAR; i--) {
-    YEAR_OPTIONS.push(i);
-  }
+  useEffect(() => {
+    setCurrYear(new Date().getFullYear());
+  }, []);
+
+  const YEAR_OPTIONS = useMemo(() => {
+    const ops: number[] = [];
+    for (let i = CURR_YEAR; i >= MIN_YEAR; i--) {
+      ops.push(i);
+    }
+    return ops;
+  }, [CURR_YEAR]);
 
   // what the year dropdown is tied to. Only visible if !== null
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);

--- a/src/components/YearSelector/index.tsx
+++ b/src/components/YearSelector/index.tsx
@@ -7,20 +7,34 @@ import {
   Popover,
   ListItemButton,
 } from '@mui/material';
-import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
-
-interface YearSelectorProps {
-  selectedYear: number;
-  onChange: Dispatch<SetStateAction<number>>;
-}
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
 
 const MIN_YEAR = 2024;
-export default function YearSelector(props: YearSelectorProps) {
+export default function YearSelector() {
+  // what the year dropdown is tied to. Only visible if !== null
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
   const [CURR_YEAR, setCurrYear] = useState<number>(0);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const [selectedYear, setSelectedYear] = useState<number>(
+    parseInt(searchParams.get('year') || String(new Date().getFullYear()))
+  );
+
   // all years from now to 2024 (launch date) in descending order
   useEffect(() => {
     setCurrYear(new Date().getFullYear());
   }, []);
+
+  useEffect(() => {
+    setSelectedYear(selectedYear);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('year', selectedYear.toString());
+
+    params.toString();
+    router.push(pathname + '?' + params);
+  }, [pathname, router, searchParams, selectedYear]);
 
   const YEAR_OPTIONS = useMemo(() => {
     const ops: number[] = [];
@@ -30,15 +44,12 @@ export default function YearSelector(props: YearSelectorProps) {
     return ops;
   }, [CURR_YEAR]);
 
-  // what the year dropdown is tied to. Only visible if !== null
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-
   return (
     <>
       <IconButton
         size="small"
-        disabled={props.selectedYear === MIN_YEAR}
-        onClick={() => props.onChange((currYear) => currYear - 1)}
+        disabled={selectedYear <= MIN_YEAR}
+        onClick={() => setSelectedYear((currYear) => currYear - 1)}
       >
         <ArrowBackIosNew sx={{ width: 15, height: 15 }} />
       </IconButton>
@@ -48,7 +59,7 @@ export default function YearSelector(props: YearSelectorProps) {
         sx={{ width: '5rem', color: 'black' }}
         onClick={(e) => setAnchorEl(e.currentTarget)}
       >
-        <Typography variant="h6">{props.selectedYear}</Typography>
+        <Typography variant="h6">{selectedYear}</Typography>
       </Button>
 
       <Popover
@@ -63,10 +74,10 @@ export default function YearSelector(props: YearSelectorProps) {
         {YEAR_OPTIONS.map((option) => (
           <ListItemButton
             key={option}
-            selected={option === props.selectedYear}
-            autoFocus={option === props.selectedYear}
+            selected={option === selectedYear}
+            autoFocus={option === selectedYear}
             onClick={() => {
-              props.onChange(option);
+              setSelectedYear(option);
               setAnchorEl(null);
             }}
           >
@@ -77,8 +88,8 @@ export default function YearSelector(props: YearSelectorProps) {
 
       <IconButton
         size="small"
-        disabled={props.selectedYear === CURR_YEAR}
-        onClick={() => props.onChange((currYear) => currYear + 1)}
+        disabled={selectedYear >= CURR_YEAR}
+        onClick={() => setSelectedYear((currYear) => currYear + 1)}
       >
         <ArrowForwardIos sx={{ width: 15, height: 15 }} />
       </IconButton>

--- a/src/server/actions/Event.ts
+++ b/src/server/actions/Event.ts
@@ -97,11 +97,12 @@ export async function getEventsBetweenDates(
       $gte: startDate,
       $lte: endDate,
     },
+    softDelete: { $ne: true },
   }).lean();
 
-  const recurringEvents = (await RecurringEventSchema.find().populate(
-    'event'
-  )) as RecurringEventResponse[];
+  const recurringEvents = (await RecurringEventSchema.find({
+    softDelete: false,
+  }).populate('event')) as RecurringEventResponse[];
 
   for (const recurringEvent of recurringEvents) {
     const dates = datesBetweenFromRrule(

--- a/src/server/actions/Organization.ts
+++ b/src/server/actions/Organization.ts
@@ -126,7 +126,9 @@ export async function getAllOrganizations(): Promise<OrganizationResponse[]> {
   try {
     await dbConnect();
 
-    organizations = await OrganizationSchema.find().lean();
+    organizations = await OrganizationSchema.find({
+      softDelete: { $ne: true },
+    }).lean();
   } catch (error) {
     throw new CMError(CMErrorType.InternalError);
   }

--- a/src/server/actions/Volunteer.ts
+++ b/src/server/actions/Volunteer.ts
@@ -56,7 +56,7 @@ export async function getAllVolunteers(): Promise<VolunteerResponse[]> {
   let volunteers: VolunteerResponse[];
   try {
     await dbConnect();
-    volunteers = await VolunteerSchema.find()
+    volunteers = await VolunteerSchema.find({ softDelete: { $ne: true } })
       .populate('previousOrganization')
       .lean();
   } catch (error) {

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,6 +1,16 @@
 import { EventResponse } from '@/types/dataModel/event';
 import { rrulestr } from 'rrule';
 
+export function getMinMaxTimestampsFromYear(year: number) {
+  const minDate = new Date(year, 0, 1);
+  minDate.setUTCHours(0, 0, 0, 0);
+
+  const maxDate = new Date(year, 11, 31);
+  maxDate.setUTCHours(23, 59, 59, 999);
+
+  return [minDate, maxDate];
+}
+
 export function datesBetweenFromRrule(
   rrule: string,
   startDate: Date,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes. Please also include relevant motivation and context. -->
- Filter out soft-deleted documents on volunteers, events, and organizations pages. They are still accessible in their individual pages.
- `YearSelector` component
- `getMinMaxTimestampsFromYear` function. Thought it might be useful in the future

Testing code for `YearSelector` component. Play around with the init value and the min/max dates in the component to test behavior if it is a different year.

```
'use client';
import YearSelector from '@/components/YearSelector';
import { useState } from 'react';

export default function Home() {
  const [selectedYear, setSelectedYear] = useState<number>(
    new Date().getFullYear()
  );
  return (
    <YearSelector selectedYear={selectedYear} onChange={setSelectedYear} />
  );
}
```

## Relevant issue(s)

<!-- List the issues related to this PR here in the format "#[ISSUE NUMBER]". Ideally, there should only be one issue per PR. -->
<!-- For example:
- #1
- #2
 -->
- #239
- #241

## Questions
<!-- Please note any questions or concerns about this PR here, or specific areas you would like reviewers to pay special attention to -->
For the `YearSelector`, any better way to prevent the parent AND the child component from specifying the max year (the current year?) I didn't want to add a ton of props and such that the parent had to set every time. Preferences?

## Type of change

<!-- Please delete options that are not relevant. -->

- [x]  New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
