### PR TITLE
263 add isadmin field to user schema and next auth

### DIFF
--- a/src/app/api/auth/[...nextauth]/auth.ts
+++ b/src/app/api/auth/[...nextauth]/auth.ts
@@ -1,8 +1,9 @@
 import { MongoDBAdapter } from '@next-auth/mongodb-adapter';
 import { MongoClient } from 'mongodb';
 import { NextAuthOptions } from 'next-auth';
-import GoogleProvider from 'next-auth/providers/google';
+import GoogleProvider, { GoogleProfile } from 'next-auth/providers/google';
 import dbConnect from '@/utils/db-connect';
+import { getUserByEmail } from '@/server/actions/User';
 
 //NextAuth using Google Provider and JWT trategy
 const clientPromise = dbConnect().then((mon) => {
@@ -15,8 +16,35 @@ export const handler: NextAuthOptions = {
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID || 'defaultClientId',
       clientSecret: process.env.GOOGLE_CLIENT_SECRET || 'defaultClientSecret',
+      profile(profile: GoogleProfile) {
+        return {
+          id: profile.sub,
+          name: profile.name,
+          email: profile.email,
+          image: profile.picture,
+          isAdmin: false,
+        }
+      }
     }),
   ],
+  callbacks: {
+    async session({ session, token }) {
+      if (token.data && session.user) {
+        session.user.isAdmin = (token.data as any).isAdmin;
+      }
+      return session;
+    },
+    async jwt({ token }) {
+      if (token.email) {
+        try {
+          const user = await getUserByEmail(token.email);
+          token.data = user
+        }
+        catch { }
+      }
+      return token
+    }
+  },
 
   session: {
     strategy: 'jwt',

--- a/src/server/actions/User.ts
+++ b/src/server/actions/User.ts
@@ -1,0 +1,19 @@
+import { UserResponse } from "@/types/dataModel/user";
+import dbConnect from "@/utils/db-connect";
+import UserSchema from '@/server/models/User'
+import CMError, { CMErrorType } from "@/utils/cmerror";
+
+
+export async function getUserByEmail(email: string): Promise<UserResponse> {
+    let user: UserResponse | null = null;
+    try {
+        await dbConnect();
+        user = await UserSchema.findOne({ email: email }).lean()
+    } catch (error) {
+        throw new CMError(CMErrorType.InternalError);
+    }
+    if (!user) {
+        throw new CMError(CMErrorType.NoSuchKey, 'User');
+    }
+    return user;
+}

--- a/src/server/models/User.ts
+++ b/src/server/models/User.ts
@@ -16,6 +16,10 @@ const UserSchema = new Schema(
             type: String,
             required: true,
         },
+        isAdmin: {
+            type: Boolean,
+            required: true,
+        }
     },
     {
         versionKey: false,

--- a/src/types/dataModel/user.ts
+++ b/src/types/dataModel/user.ts
@@ -5,6 +5,7 @@ const zUser = z.object({
     name: z.string(),
     email: z.string(),
     image: z.string(),
+    isAdmin: z.boolean(),
 })
 
 export const zUserEntity = zUser.extend(zBase.shape);

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -23,6 +23,12 @@ declare module 'next-auth' {
       email: string;
       /** The user's image. */
       image: string;
+
+      isAdmin: boolean;
     };
+  }
+
+  interface User {
+    isAdmin: boolean;
   }
 }


### PR DESCRIPTION
# Description
Added functionality for custom isAdmin field in user model which is automatically set to false by default, updated data types to match.

## Relevant issue(s)

#263 

## Questions

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have assigned reviewers to this PR

### Testing steps

add a middleware in the src/middleware.ts file (do this by specifying a route that is authenticated). Then, use the useSession hook to get the session data back from the server when logged in and console log that. You should see the user field has an isAdmin field in it.

also ensure that when you sign in with a new email that the new user is created with the isAdmin field set to false.