### PR TITLE
266 create server funcapi endpoint for updating allowed users

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -14,7 +14,7 @@ export async function PUT(request: NextRequest) {
       throw new CMError(CMErrorType.BadValue, 'Request')
     }
 
-    updateAllowedUsers(req)
+    updateAllowedUsers(validationResult.data)
     return new NextResponse(undefined, { status: 204 })
   } catch (e) {
     return CMErrorResponse(e)

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,22 @@
+import { updateAllowedUsers } from "@/server/actions/User";
+import { zUpdateAllowedUsersRequest } from "@/types/dataModel/user";
+import { adminAuth } from "@/utils/auth";
+import CMError, { CMErrorResponse, CMErrorType } from "@/utils/cmerror";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function PUT(request: NextRequest) {
+  try {
+    await adminAuth();
+
+    const req = await request.json();
+    const validationResult = zUpdateAllowedUsersRequest.safeParse(req);
+    if (!validationResult.success) {
+      throw new CMError(CMErrorType.BadValue, 'Request')
+    }
+
+    updateAllowedUsers(req)
+    return new NextResponse(undefined, { status: 204 })
+  } catch (e) {
+    return CMErrorResponse(e)
+  }
+}

--- a/src/server/actions/User.ts
+++ b/src/server/actions/User.ts
@@ -54,8 +54,14 @@ export async function updateAllowedUsers(req: UpdateAllowedUsersRequest) {
   try {
     await dbConnect();
 
-    await addAdmins(req.adminIds)
-    await Settings.updateOne({ _id: (await getSettings())._id }, { allowedEmails: req.userEmails })
+    if (req.userEmails) {
+      const currentSettings = await getSettings()
+      const newAllowedEmails = currentSettings.allowedEmails.concat(req.userEmails)
+      await Settings.updateOne({ _id: (await getSettings())._id }, { allowedEmails: newAllowedEmails })
+    }
+    if (req.adminIds) {
+      await addAdmins(req.adminIds)
+    }
   } catch (e) {
     throw new CMError(CMErrorType.InternalError)
   }

--- a/src/server/actions/User.ts
+++ b/src/server/actions/User.ts
@@ -1,7 +1,9 @@
-import { UserResponse } from '@/types/dataModel/user';
+import { UpdateAllowedUsersRequest, UserResponse } from '@/types/dataModel/user';
 import dbConnect from '@/utils/db-connect';
 import UserSchema from '@/server/models/User';
 import CMError, { CMErrorType } from '@/utils/cmerror';
+import Settings from '../models/Settings';
+import { getSettings } from './Settings';
 
 export async function getUserByEmail(email: string): Promise<UserResponse> {
   let user: UserResponse | null = null;
@@ -45,5 +47,16 @@ export async function removeAdmin(userId: string): Promise<void> {
     await UserSchema.updateOne({ _id: userId }, { isAdmin: false });
   } catch (error) {
     throw new CMError(CMErrorType.InternalError);
+  }
+}
+
+export async function updateAllowedUsers(req: UpdateAllowedUsersRequest) {
+  try {
+    await dbConnect();
+
+    await addAdmins(req.adminIds)
+    await Settings.updateOne({ _id: (await getSettings())._id }, { allowedEmails: req.userEmails })
+  } catch (e) {
+    throw new CMError(CMErrorType.InternalError)
   }
 }

--- a/src/server/actions/User.ts
+++ b/src/server/actions/User.ts
@@ -54,11 +54,15 @@ export async function updateAllowedUsers(req: UpdateAllowedUsersRequest) {
   try {
     await dbConnect();
 
+    // if userEmails is defined, append new unique emails to array
     if (req.userEmails) {
       const currentSettings = await getSettings()
-      const newAllowedEmails = currentSettings.allowedEmails.concat(req.userEmails)
+      // Concatenate values, then cast to set and back to remove duplicate entries
+      const newAllowedEmails = [...new Set(currentSettings.allowedEmails.concat(req.userEmails))]
+      // Replace old arr with new arr
       await Settings.updateOne({ _id: (await getSettings())._id }, { allowedEmails: newAllowedEmails })
     }
+    // if adminIds is defined, flag users as admins
     if (req.adminIds) {
       await addAdmins(req.adminIds)
     }

--- a/src/types/dataModel/user.ts
+++ b/src/types/dataModel/user.ts
@@ -13,9 +13,16 @@ export const zUserResponse = zUserEntity;
 
 export const zAddAdminRequest = z.array(zObjectId);
 
-export interface User extends z.infer<typeof zUser> {}
-export interface UserEntity extends z.infer<typeof zUserEntity> {}
-export interface UserResponse extends z.infer<typeof zUserResponse> {}
-export interface AddAdminRequest extends z.infer<typeof zAddAdminRequest> {}
+export const zUpdateAllowedUsersRequest = z.object({
+  userEmails: z.array(z.string()),
+  adminIds: z.array(zObjectId),
+})
+
+export interface User extends z.infer<typeof zUser> { }
+export interface UserEntity extends z.infer<typeof zUserEntity> { }
+export interface UserResponse extends z.infer<typeof zUserResponse> { }
+export interface AddAdminRequest extends z.infer<typeof zAddAdminRequest> { }
+
+export interface UpdateAllowedUsersRequest extends z.infer<typeof zUpdateAllowedUsersRequest> { }
 
 export default zUser;

--- a/src/types/dataModel/user.ts
+++ b/src/types/dataModel/user.ts
@@ -14,8 +14,8 @@ export const zUserResponse = zUserEntity;
 export const zAddAdminRequest = z.array(zObjectId);
 
 export const zUpdateAllowedUsersRequest = z.object({
-  userEmails: z.array(z.string()),
-  adminIds: z.array(zObjectId),
+  userEmails: z.array(z.string().email()).optional(),
+  adminIds: z.array(zObjectId).optional(),
 })
 
 export interface User extends z.infer<typeof zUser> { }


### PR DESCRIPTION
# Description
#266 

## Questions
It seems sketchy to be overwriting the Settings schema directly from the server func, but there's no existing server func for adding emails to the Settings schema.
It also seems sketchy to just pass the request directly into the server func, though that's what the issue said to do. Should we validate that the user ids correspond to actual users first?

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have assigned reviewers to this PR

## To test

Log in as an admin and send a PUT request to `/api/users` that looks something like this
```
{
    "userEmails": ["ethanhmaness@gmail.com", "emaness@vols.utk.edu"],
    "adminIds": ["6625acc38b667741185a92ae", "662921e0e3a3ebfe912a9200"]
}
```

Send it a second time to check that it doesn't add duplicate emails.

NOTE: You can't use Postman for this, gotta do it directly thru the browser so your account can be authenticated.